### PR TITLE
Bringing master up to date with chef-partners/chef-provisioning-vra master

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,23 @@
+### Versions:
+<!--- Version of the software where you are encountering the issue --->
+<!-- You should probably update in this is not newest release.--->
+* Version of chef-provisioning-vra:
+* Version of chef-provisioning:
+* Version of chef:
+
+### Platform Details
+<!--- What version of vRA are you running? What version of ESXi are you using too?--->
+* Version of vRA:
+* Version of ESXi:
+
+### Scenario:
+<!--- What you are trying to achieve and you can't?--->
+
+### Steps to Reproduce:
+<!--- If you are filing an issue what are the things we need to do in order to repro your problem? How are you using this gem or any resources it includes?--->
+
+### Expected Result:
+<!--- What are you expecting to happen as the consequence of above reproduction steps?--->
+
+### Actual Result:
+<!--- What actually happens after the reproduction steps? Include the error output or a link to a gist if possible.--->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+### Description
+
+<!--- Describe what this change achieves--->
+
+### Issues Resolved
+
+<!--- List any existing issues this PR resolves--->
+
+### Check List
+
+- [ ] All tests pass.
+- [ ] All style checks pass.
+- [ ] Functionality includes testing.
+- [ ] Functionality has been documented in the README if applicable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - 'spec/**/*'
+    - 'vendor/**/*'
 Metrics/AbcSize:
   Max: 50
 Metrics/ClassLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ cache: bundler
 sudo: false
 
 rvm:
-- 2.2.2
-- 2.3.1
+  - 2.2.2
+  - 2.3.1
+  - 2.4.1
 
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # chef-provisioning-vra CHANGELOG
 
+## v1.0.0 (2016-12-15)
+
+* Updated to the new `vmware-vra` gem. Now supports 7.0+ vRA.
+
 ## v0.3.0 (2016-01-06)
 
 * [pr#7](https://github.com/chef-partners/chef-provisioning-vra/pull/7) Storing the vRA resource (host) name in the Chef node object so it can be displayed/queried in cases where the machine resource name does not match the vRA-generated hostname
@@ -15,4 +19,3 @@
 
 ## v0.1.0
 * Initial release
-

--- a/chef-provisioning-vra.gemspec
+++ b/chef-provisioning-vra.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'chef-provisioning'
-  spec.add_dependency 'vmware-vra',            '~> 1.3'
+  spec.add_dependency 'vmware-vra',            '~> 2.0'
 
   spec.add_development_dependency 'chef',      '>= 12'
   spec.add_development_dependency 'bundler',   '~> 1.7'

--- a/lib/chef/provisioning/vra_driver/version.rb
+++ b/lib/chef/provisioning/vra_driver/version.rb
@@ -20,7 +20,7 @@
 class Chef
   module Provisioning
     module VraDriver
-      VERSION = '0.3.0'.freeze
+      VERSION = '1.0.0'.freeze
     end
   end
 end


### PR DESCRIPTION
I just got wind we are going to be upgrading to vRealize v7 later this month. With the current version of chef-provisioning-vra, we can only support v6, and not v7.